### PR TITLE
feat: support all MySQL charset in TiDB parser

### DIFF
--- a/parser/charset/charset.go
+++ b/parser/charset/charset.go
@@ -152,8 +152,11 @@ func GetCharsetInfo(cs string) (*Charset, error) {
 		return c, nil
 	}
 
+	// TiDB unsupported charset, but MySQL supported.
 	if c, ok := charsets[strings.ToLower(cs)]; ok {
-		return c, errors.Errorf("Unsupported charset %s", cs)
+		// TiDB doesn't support all the charsets in MySQL.
+		// But we can use the charset info from MySQL.
+		return c, nil
 	}
 
 	return nil, errors.Errorf("Unknown charset %s", cs)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -2335,6 +2335,7 @@ func TestDDL(t *testing.T) {
 		{"create table t (a int default (((rand()))))", true, "CREATE TABLE `t` (`a` INT DEFAULT RAND())"},
 		{"create table t (a int default (((rand(1)))))", true, "CREATE TABLE `t` (`a` INT DEFAULT RAND(1))"},
 		{"create table t (a int default replace(uuid(), '-', ''))", true, "CREATE TABLE `t` (`a` INT DEFAULT REPLACE(UUID(), _UTF8MB4'-', _UTF8MB4''))"},
+		{"CREATE TABLE t( a varchar(60) CHARACTER SET ucs2 COLLATE ucs2_general_ci);", true, "CREATE TABLE `t` (`a` VARCHAR(60) CHARACTER SET UCS2 COLLATE ucs2_general_ci)"},
 
 		{"CREATE", false, ""},
 		{"CREATE TABLE", false, ""},


### PR DESCRIPTION
TiDB only supports 5 charsets, but as MySQL parser, TiDB parser should support all MySQL charsets.